### PR TITLE
fix for hosting OWA behind load balanced environment

### DIFF
--- a/modules/base/classes/trackingEventHelpers.php
+++ b/modules/base/classes/trackingEventHelpers.php
@@ -221,8 +221,17 @@ class owa_trackingEventHelpers {
 	}
 	
 	static function ipAddressDefault() {
+	
+		return owa_coreAPI::getServerParam(self::getIp());
+	}
+	
+	static function getIp() {
 		
-		return owa_coreAPI::getServerParam('REMOTE_ADDR');	
+		if (!empty($_SERVER['HTTP_X_FORWARDED_FOR'])) {
+			return 'HTTP_X_FORWARDED_FOR';
+		} else {
+			return 'REMOTE_ADDR';
+		}
 	}
 	
 	static function timestampDefault() {


### PR DESCRIPTION
This allows the tracker to detect if a reverse proxy is being used, and will return the server param to grab the ISO standard  HTTP_X_FORWARDED_FOR header, instead of the default REMOTE_ADDR.

This is a much more "environment independent" solution, than mod_rpaf as suggested in other issues
