### PR TITLE
Duplicate property

### DIFF
--- a/modules/base/js/owa.areachart.js
+++ b/modules/base/js/owa.areachart.js
@@ -14,7 +14,6 @@ OWA.areaChart = function( options ) {
 		showGrid: true,
 		showLegend: true,
 		showDots: true,
-		showLegend: true,
 		lineWidth: 4,
 		autoResizeCharts: true,
 		fillColor: "rgba(202,225,255, 0.6)",


### PR DESCRIPTION
Listing the same property twice in one object literal is redundant and may indicate a copy-paste mistake.

In ECMAScript 2015 and above, as well as ECMAScript 5 non-strict mode, an object literal may define the same property multiple times, with later definitions overwriting earlier ones. If all definitions assign the same value to the property, this will not to lead to problems at runtime, but it makes the code harder to read and maintain.