### PR TITLE
Update owa.tracker.js to prevent race condition with duplicate tracked events

### DIFF
--- a/modules/base/js/owa.tracker.js
+++ b/modules/base/js/owa.tracker.js
@@ -930,8 +930,9 @@ OWA.tracker.prototype = {
         	var doc = that.getIframeDocument( iframe );
             
             if ( doc ) {
+		    clearInterval(timer); //clear the interval before submitting data, race condition could occur otherwise resulting in duplicate tracked events
             	that.postFromIframe(iframe, data);
-				clearInterval(timer);
+				
             }
 			
 			            


### PR DESCRIPTION
Move the clearInterval above the iframe data push to prevent race conditions where duplicate data gets logged/tracked.