### PR TITLE
Getting Error while install of Open Web Analytics 1.6.4

### DIFF
--- a/owa_lib.php
+++ b/owa_lib.php
@@ -1009,7 +1009,7 @@ class owa_lib {
 		if ( function_exists(password_hash) ) {
 			return password_hash( $password, PASSWORD_DEFAULT );
 		} else {
-			return $this->encryptOldPassword($password);
+			return self::encryptOldPassword($password);
 		}
 	}
 	


### PR DESCRIPTION
Hi,

i am getting error while install of ``Open Web Analytics`` 1.6.4

```
Warning: mysqli_fetch_assoc() expects parameter 1 to be mysqli_result, boolean given in plugins/db/owa_db_mysql.php on line 220

Fatal error: Using $this when not in object context in owa_lib.php on line 1012
```

after debug i found

```php
	/**
	 * Simple Password Encryption
	 *
	 * @param string $password
	 * @return string
	 */
	public static function encryptOldPassword($password) {
		
		return md5(strtolower($password).strlen($password));
		//return owa_coreAPI::saltedHash( $password, 'auth');
	}
	public static function encryptPassword($password) {
		
		// check function exists to support older PHP
		if ( function_exists(password_hash) ) {
			return password_hash( $password, PASSWORD_DEFAULT );
		} else {
			return $this->encryptOldPassword($password);
		}
	}
```
you calling ``encryptOldPassword`` static function with $this

