### PR TITLE
Bugfix: Visitor history avatar not displayed when visitor_avatar_id not set

### DIFF
--- a/modules/base/templates/report_visitor.tpl
+++ b/modules/base/templates/report_visitor.tpl
@@ -1,6 +1,6 @@
 <div>
 	<div style="display: table-cell; vertical-align: middle">
-		<span><img class="owa_avatar" style="vertical-align:middle;" src="<?php echo $this->getAvatarImage( $this->out($this->get('visitor_avatar_id') ) );?>" /></span>
+		<span><img class="owa_avatar" style="vertical-align:middle;" src="<?php echo $this->getAvatarImage( $this->get('visitor_avatar_id') );?>" /></span>
 		<span class="inline_h2"><?php $this->out( $visitor_label );?></span>
 	</div>
 	<BR>

--- a/owa_template.php
+++ b/owa_template.php
@@ -901,7 +901,7 @@ class owa_template extends Template {
 	
 	function getAvatarImage($email) {
 		
-		if (false != $email) {
+		if (false != $email && $email !== '(not set)') {
 			$url = sprintf("https://www.gravatar.com/avatar/%s?s=30", md5($email));
 		} else {
 			$url = $this->makeImageLink('base/i/default_user_50x50.png');


### PR DESCRIPTION
 Always respond with 404, because url always gets '(not set)' prepended.