### PR TITLE
Bugfix: Catch query errors

### DIFF
--- a/plugins/db/owa_db_mysql.php
+++ b/plugins/db/owa_db_mysql.php
@@ -217,6 +217,11 @@ class owa_db_mysql extends owa_db {
 		}
 	
 		//$this->result = array();
+
+        if (!$this->new_result) {
+            return null;
+        }
+
 		while ( $row = mysqli_fetch_assoc( $this->new_result ) ) {
 			
 			array_push($this->result, $row);


### PR DESCRIPTION
mysqli_fetch_assoc() expects parameter 1 to be mysqli_result, bool given in /var/www/owa/plugins/db/owa_db_mysql.php on line 220

Ref: #432 