### PR TITLE
Bugfix: Manually provided location properties getting ignored

### DIFF
--- a/modules/base/classes/trackingEventHelpers.php
+++ b/modules/base/classes/trackingEventHelpers.php
@@ -676,71 +676,79 @@ class owa_trackingEventHelpers {
 	}
 	
 	static function resolveEntryPage( $is_entry_page, $event ) {
-		
-		if ( $event->get( 'is_new_session' ) ) {
-			
-			return true;	
-		}
+        return $event->get('is_new_session') ? true : false;
 	}
 	
 	static function resolveCountry ( $country, $event ) {
-		
-		if ( ! $country ) {
-			
-			$location = owa_coreAPI::getGeolocationFromIpAddress( $event->get( 'ip_address' ) );
-			
-			return $location->getCountry();
-		}
+
+	    // if country is set manually, use it
+		if ($country) {
+            return $country;
+        }
+
+        $location = owa_coreAPI::getGeolocationFromIpAddress($event->get('ip_address'));
+
+        return $location->getCountry();
 	}
 	
 	static function resolveCity ( $city, $event ) {
-		
-		if ( ! $city ) {
+
+        // if city is set manually, use it
+        if ($city) {
+            return $city;
+        }
 			
-			$location = owa_coreAPI::getGeolocationFromIpAddress( $event->get( 'ip_address' ) );
-			
-			return $location->getCity();
-		}
+        $location = owa_coreAPI::getGeolocationFromIpAddress( $event->get( 'ip_address' ) );
+
+        return $location->getCity();
 	}
 	
 	static function resolveLatitude ( $latitude, $event ) {
-		
-		if ( ! $latitude ) {
+
+        // if latitude is set manually, use it
+        if ($latitude) {
+            return $latitude;
+        }
 			
-			$location = owa_coreAPI::getGeolocationFromIpAddress( $event->get( 'ip_address' ) );
-			
-			return $location->getLatitude();
-		}
+        $location = owa_coreAPI::getGeolocationFromIpAddress( $event->get( 'ip_address' ) );
+
+        return $location->getLatitude();
 	}
 	
 	static function resolveLongitude ( $longitude, $event ) {
-		
-		if ( ! $longitude ) {
+
+        // if longitude is set manually, use it
+        if ($longitude) {
+            return $longitude;
+        }
 			
-			$location = owa_coreAPI::getGeolocationFromIpAddress( $event->get( 'ip_address' ) );
-			
-			return $location->getLongitude();
-		}
+        $location = owa_coreAPI::getGeolocationFromIpAddress( $event->get( 'ip_address' ) );
+
+        return $location->getLongitude();
 	}
 	
 	static function resolveCountryCode ( $country_code, $event ) {
-		
-		if ( ! $country_code ) {
+
+        // if country_code is set manually, use it
+        if ($country_code) {
+            return $country_code;
+        }
 			
-			$location = owa_coreAPI::getGeolocationFromIpAddress( $event->get( 'ip_address' ) );
-			
-			return $location->getCountryCode();
-		}
+        $location = owa_coreAPI::getGeolocationFromIpAddress( $event->get( 'ip_address' ) );
+
+        return $location->getCountryCode();
 	}
 	
 	static function resolveState ( $state, $event ) {
-		
-		if ( ! $state ) {
+
+        // if state is set manually, use it
+        if ($state) {
+            return $state;
+        }
 			
-			$location = owa_coreAPI::getGeolocationFromIpAddress( $event->get( 'ip_address' ) );
-			
-			return $location->getState();
-		}
+        $location = owa_coreAPI::getGeolocationFromIpAddress( $event->get( 'ip_address' ) );
+
+        return $location->getState();
 	}
 	
 	static function lowercaseString ( $string, $event ) {
@@ -749,21 +757,25 @@ class owa_trackingEventHelpers {
 	}
 	
 	static function setPriorPage ( $prior_page, $event ) {
+
+        // if prior_page is set manually, use it
+        if ($prior_page) {
+            return $prior_page;
+        }
 		
-		if ( ! $prior_page ) {
-		
-			if ( $event->get( 'HTTP_REFERER' ) ) {
-				// @todo is this parse done somewhere else already? source?	
-				$referer_parse = owa_lib::parse_url( $event->get('HTTP_REFERER') );
-				
-				$http_host = $event->get( 'HTTP_HOST' );
-	
-				if ( isset($referer_parse['host'] ) && $referer_parse['host'] === $http_host ) {
-					
-					return $event->get('HTTP_REFERER');	
-				}
-			}
-		}
+        if ( $event->get( 'HTTP_REFERER' ) ) {
+            // @todo is this parse done somewhere else already? source?
+            $referer_parse = owa_lib::parse_url( $event->get('HTTP_REFERER') );
+
+            $http_host = $event->get( 'HTTP_HOST' );
+
+            if ( isset($referer_parse['host'] ) && $referer_parse['host'] === $http_host ) {
+
+                return $event->get('HTTP_REFERER');
+            }
+        }
+
+        return null;
 	}
 	
 	static function setSearchTerms ( $search_terms, $event ) {


### PR DESCRIPTION
Manually set location properties like the following getting ignored.

```
$owa = new owa_php();
$owa->setProperty('country', 'Germany');
```

Because `owa_trackingEventHelpers::resolveCountry` returns null, when the value is already set.
So `owa_eventDispatch::filter` assigns null to the value variable and returns null.

Which result in `owa_trackingEventHelpers::setTrackerProperties` overriding the already set property with null, in line 138.

