### PR TITLE
Feature: Global settings for cookie persistence

### DIFF
--- a/modules/base/classes/settings.php
+++ b/modules/base/classes/settings.php
@@ -641,6 +641,7 @@
 				'remote_event_queue_type'			=> 'http',
 				'remote_event_queue_endpoint'		=> '',
 				'cookie_domain'						=> false,
+                'cookie_persistence'                => true,  // Controls persistence of cookies, only for use in europe needed
 				'ws_timeout'						=> 10,
 				'is_active'							=> true,
 				'per_site_visitors'					=> false, // remove

--- a/owa_coreAPI.php
+++ b/owa_coreAPI.php
@@ -1087,7 +1087,12 @@ class owa_coreAPI {
 		
 		// debug
 		owa_coreAPI::debug(sprintf('Setting cookie %s with values: %s under domain: %s', $cookie_name, $cookie_value, $domain));
-		
+
+		// makes cookie to session cookie only
+        if (!owa_coreAPI::getSetting('base', 'cookie_persistence')) {
+            $expires = 0;
+        }
+
 		// set compact privacy header
 		header(sprintf('P3P: CP="%s"', owa_coreAPI::getSetting('base', 'p3p_policy')));
 		//owa_coreAPI::debug('time: '.$expires);


### PR DESCRIPTION
Added option to disable cookie persistence. This feature will disable the "unique visitor" functionality, because the cookies are session cookies only.

This is useful in europe, where you have to add a cookie consent tool when you have persistent tracking cookies on our site.

My experience is that nowadays many visitors won´t accept such cookies and you can not track them. This is also why I switched from Google Analytics to OpenWebAnalytics. 