### PR TITLE
Bugfix: Fixed a bug where already parsed json is parsed a second time

### DIFF
--- a/modules/base/reportAttributionHistory.php
+++ b/modules/base/reportAttributionHistory.php
@@ -47,7 +47,11 @@ class owa_reportAttributionHistoryController extends owa_reportController {
 		$this->set('gridFormatters', array('latestAttributions' =>
 				"function(value) {
 					if (value) {
-						table = jQuery('#attributionCell').jqote(JSON.parse(value), '*');
+					    if (typeof value !== 'object') {
+                            value = JSON.parse(value);
+                        }
+					
+						table = jQuery('#attributionCell').jqote(value, '*');
 						return table;
 					} else {
 						return '(none)';


### PR DESCRIPTION
Uncaught SyntaxError: Unexpected token o in JSON at position 1
    at JSON.parse (<anonymous>)
    at HTMLTableElement.dim.options.grid.columnFormatters.latestAttributions (index.php?owa_siteId=XXX&owa_period=last_seven_days&owa_do=base.reportAttributionHistory:425)
    at M (owa.reporting-combined-min.js?version=1.6.4:2310)
    at R (owa.reporting-combined-min.js?version=1.6.4:2310)
    at ra (owa.reporting-combined-min.js?version=1.6.4:2320)
    at HTMLTableElement.a.addJSONData (owa.reporting-combined-min.js?version=1.6.4:2374)
    at OWA.dataGrid.addAllRowsToGrid (owa.reporting-combined-min.js?version=1.6.4:2904)
    at OWA.dataGrid.display (owa.reporting-combined-min.js?version=1.6.4:2904)
    at OWA.dataGrid.generate (owa.reporting-combined-min.js?version=1.6.4:2904)
    at OWA.resultSetExplorer.createGrid (owa.reporting-combined-min.js?version=1.6.4:2904)